### PR TITLE
Add media center page with LinkedIn and Twitter sections

### DIFF
--- a/media-center.html
+++ b/media-center.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <title>المركز الإعلامي</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    section { margin-bottom: 40px; }
+    h2 { font-size: 1.5em; }
+  </style>
+</head>
+<body>
+  <h1>المركز الإعلامي</h1>
+
+  <section id="linkedin">
+    <h2>أحدث منشورات لينكدإن</h2>
+    <div id="linkedin-posts"></div>
+  </section>
+
+  <section id="twitter">
+    <h2>آخر التغريدات</h2>
+    <a class="twitter-timeline" data-lang="ar" data-width="400" data-height="600" href="https://twitter.com/aladwan_co">التغريدات بواسطة @aladwan_co</a>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  </section>
+
+  <section id="instagram">
+    <h2>معرض صور إنستقرام</h2>
+    <a href="index.html">عرض المعرض</a>
+  </section>
+
+  <script>
+    async function fetchLinkedInPosts() {
+      const accessToken = 'YOUR_LINKEDIN_ACCESS_TOKEN';
+      const personUrn = 'urn:li:person:YOUR_PERSON_URN';
+      const url = `https://api.linkedin.com/v2/shares?q=owners&owners=${encodeURIComponent(personUrn)}&sortBy=LAST_MODIFIED&sharesPerOwner=5`;
+
+      try {
+        const response = await fetch(url, {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`
+          }
+        });
+        const data = await response.json();
+        const container = document.getElementById('linkedin-posts');
+
+        data.elements.forEach(post => {
+          const div = document.createElement('div');
+          const text = post.text && post.text.text ? post.text.text : 'منشور بدون نص';
+          div.textContent = text;
+          container.appendChild(div);
+        });
+      } catch (error) {
+        console.error('Failed to fetch LinkedIn posts', error);
+      }
+    }
+
+    fetchLinkedInPosts();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create media center page titled "المركز الإعلامي" featuring sections for LinkedIn posts and latest tweets
- Include script template for fetching LinkedIn posts via API
- Link to existing Instagram gallery

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99cb07448832e8b0da56f3e4b01c4