### PR TITLE
Add home navigation and dedicated job application form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>نموذج الاتصال - شركة العدوان</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+
+  <div class="container py-5">
+    <div class="card contact-card">
+      <div class="card-header contact-header text-center position-relative">
+        <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
+        <h3 id="formTitle">نموذج الاتصال</h3>
+      </div>
+      <div class="card-body">
+        <form id="contactForm" enctype="multipart/form-data" novalidate>
+          <div class="mb-3">
+            <label class="form-label" id="userTypeLabel">نوع المستخدم</label>
+            <select class="form-select" id="userType" required>
+              <option value="">اختر</option>
+              <option value="individual">فرد</option>
+              <option value="company">شركة</option>
+              <option value="government">جهة حكومية</option>
+            </select>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label" id="inquiryTypeLabel">نوع الاستفسار</label>
+            <select class="form-select" id="inquiryType" required>
+              <option value="">اختر</option>
+              <option value="job">وظيفة</option>
+              <option value="question">استفسار</option>
+              <option value="complaint">شكوى</option>
+            </select>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label" id="subjectLabel">عنوان الرسالة</label>
+            <input type="text" class="form-control" id="subject" maxlength="50" required>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label" id="fullNameLabel">الاسم الكامل</label>
+            <input type="text" class="form-control" id="fullName" required>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label" id="emailLabel">البريد الإلكتروني</label>
+            <input type="email" class="form-control" id="email" required>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label" id="phoneLabel">رقم التواصل</label>
+            <input type="tel" class="form-control" id="phone" required>
+          </div>
+
+          <div class="mb-3" id="cvField" style="display: none;">
+            <label class="form-label" id="cvLabel">تحميل السيرة الذاتية (PDF فقط - 5MB)</label>
+            <input type="file" class="form-control" id="cvUpload" accept=".pdf" required>
+          </div>
+
+          <div class="mb-3" id="messageField">
+            <label class="form-label" id="messageLabel">نص الرسالة</label>
+            <textarea class="form-control" id="message" rows="4" required></textarea>
+          </div>
+
+          <div class="d-grid">
+            <button type="submit" class="btn btn-primary" id="submitBtn">إرسال</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/inbox.js
+++ b/inbox.js
@@ -53,6 +53,7 @@ const translations = {
 let currentLang = "ar";
 
 function addField(label, value) {
+  if (!value) return;
   const p = document.createElement("p");
   const strong = document.createElement("strong");
   strong.textContent = label;

--- a/index.html
+++ b/index.html
@@ -3,78 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>نموذج الاتصال - شركة العدوان</title>
+  <title>شركة العدوان</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
   <link href="style.css" rel="stylesheet" />
 </head>
 <body>
-
-  <div class="container py-5">
-    <div class="card contact-card">
-      <div class="card-header contact-header text-center position-relative">
-        <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
-        <h3 id="formTitle">نموذج الاتصال</h3>
-      </div>
-      <div class="card-body">
-        <form id="contactForm" enctype="multipart/form-data" novalidate>
-          <div class="mb-3">
-            <label class="form-label" id="userTypeLabel">نوع المستخدم</label>
-            <select class="form-select" id="userType" required>
-              <option value="">اختر</option>
-              <option value="individual">فرد</option>
-              <option value="company">شركة</option>
-              <option value="government">جهة حكومية</option>
-            </select>
-          </div>
-
-          <div class="mb-3">
-            <label class="form-label" id="inquiryTypeLabel">نوع الاستفسار</label>
-            <select class="form-select" id="inquiryType" required>
-              <option value="">اختر</option>
-              <option value="job">وظيفة</option>
-              <option value="question">استفسار</option>
-              <option value="complaint">شكوى</option>
-            </select>
-          </div>
-
-          <div class="mb-3">
-            <label class="form-label" id="subjectLabel">عنوان الرسالة</label>
-            <input type="text" class="form-control" id="subject" maxlength="50" required>
-          </div>
-
-          <div class="mb-3">
-            <label class="form-label" id="fullNameLabel">الاسم الكامل</label>
-            <input type="text" class="form-control" id="fullName" required>
-          </div>
-
-          <div class="mb-3">
-            <label class="form-label" id="emailLabel">البريد الإلكتروني</label>
-            <input type="email" class="form-control" id="email" required>
-          </div>
-
-          <div class="mb-3">
-            <label class="form-label" id="phoneLabel">رقم التواصل</label>
-            <input type="tel" class="form-control" id="phone" required>
-          </div>
-
-          <div class="mb-3" id="cvField" style="display: none;">
-            <label class="form-label" id="cvLabel">تحميل السيرة الذاتية (PDF فقط - 5MB)</label>
-            <input type="file" class="form-control" id="cvUpload" accept=".pdf" required>
-          </div>
-
-          <div class="mb-3" id="messageField">
-            <label class="form-label" id="messageLabel">نص الرسالة</label>
-            <textarea class="form-control" id="message" rows="4" required></textarea>
-          </div>
-
-          <div class="d-grid">
-            <button type="submit" class="btn btn-primary" id="submitBtn">إرسال</button>
-          </div>
-        </form>
-      </div>
+  <div class="container py-5 text-center">
+    <div class="d-grid gap-3 col-6 mx-auto">
+      <a href="contact.html" class="btn btn-primary btn-lg">اتصل بنا</a>
+      <a href="jobs.html" class="btn btn-secondary btn-lg">الوظائف</a>
     </div>
   </div>
-
-  <script src="script.js"></script>
 </body>
 </html>

--- a/job.js
+++ b/job.js
@@ -1,0 +1,87 @@
+const translations = {
+  ar: {
+    langToggle: "English",
+    formTitle: "نموذج التوظيف",
+    subjectLabel: "عنوان الرسالة",
+    fullNameLabel: "الاسم الكامل",
+    emailLabel: "البريد الإلكتروني",
+    phoneLabel: "رقم التواصل",
+    messageLabel: "الموضوع",
+    cvLabel: "تحميل السيرة الذاتية (PDF فقط - 5MB)",
+    submitBtn: "إرسال",
+    alerts: {
+      pdf: "⚠️ يجب أن يكون الملف بصيغة PDF",
+      size: "⚠️ الحد الأقصى لحجم السيرة الذاتية هو 5 ميجابايت"
+    }
+  },
+  en: {
+    langToggle: "العربية",
+    formTitle: "Job Application",
+    subjectLabel: "Subject",
+    fullNameLabel: "Full Name",
+    emailLabel: "Email",
+    phoneLabel: "Phone Number",
+    messageLabel: "Message",
+    cvLabel: "Upload CV (PDF only - 5MB)",
+    submitBtn: "Send",
+    alerts: {
+      pdf: "⚠️ File must be PDF",
+      size: "⚠️ CV size limit is 5MB"
+    }
+  }
+};
+
+let currentLang = "ar";
+
+function setLanguage(lang) {
+  const t = translations[lang];
+  document.documentElement.lang = lang;
+  document.documentElement.dir = lang === "ar" ? "rtl" : "ltr";
+
+  document.getElementById("langToggle").textContent = t.langToggle;
+  document.getElementById("formTitle").textContent = t.formTitle;
+  document.getElementById("subjectLabel").textContent = t.subjectLabel;
+  document.getElementById("fullNameLabel").textContent = t.fullNameLabel;
+  document.getElementById("emailLabel").textContent = t.emailLabel;
+  document.getElementById("phoneLabel").textContent = t.phoneLabel;
+  document.getElementById("messageLabel").textContent = t.messageLabel;
+  document.getElementById("cvLabel").textContent = t.cvLabel;
+  document.getElementById("submitBtn").textContent = t.submitBtn;
+}
+
+document.getElementById("langToggle").addEventListener("click", () => {
+  currentLang = currentLang === "ar" ? "en" : "ar";
+  setLanguage(currentLang);
+});
+
+document.getElementById("jobForm").addEventListener("submit", function (e) {
+  e.preventDefault();
+  const cvInput = document.getElementById("cvUpload");
+  if (cvInput.files.length > 0) {
+    const file = cvInput.files[0];
+    const ext = file.name.split(".").pop().toLowerCase();
+    if (ext !== "pdf") {
+      alert(translations[currentLang].alerts.pdf);
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      alert(translations[currentLang].alerts.size);
+      return;
+    }
+  }
+
+  const params = new URLSearchParams({
+    to: "career@example.com",
+    subject: document.getElementById("subject").value,
+    name: document.getElementById("fullName").value,
+    email: document.getElementById("email").value,
+    phone: document.getElementById("phone").value,
+    message: document.getElementById("message").value,
+    inquiryType: "job",
+    filename: cvInput.files.length > 0 ? cvInput.files[0].name : ""
+  });
+
+  window.location.href = `inbox.html?${params.toString()}`;
+});
+
+setLanguage("ar");

--- a/jobs.html
+++ b/jobs.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>الوظائف - شركة العدوان</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <div class="container py-5">
+    <div class="card contact-card">
+      <div class="card-header contact-header text-center position-relative">
+        <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
+        <h3 id="formTitle">نموذج التوظيف</h3>
+      </div>
+      <div class="card-body">
+        <form id="jobForm" enctype="multipart/form-data" novalidate>
+          <div class="mb-3">
+            <label class="form-label" id="subjectLabel">عنوان الرسالة</label>
+            <input type="text" class="form-control" id="subject" maxlength="50" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" id="fullNameLabel">الاسم الكامل</label>
+            <input type="text" class="form-control" id="fullName" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" id="emailLabel">البريد الإلكتروني</label>
+            <input type="email" class="form-control" id="email" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" id="phoneLabel">رقم التواصل</label>
+            <input type="tel" class="form-control" id="phone" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" id="messageLabel">الموضوع</label>
+            <textarea class="form-control" id="message" rows="4" required></textarea>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" id="cvLabel">تحميل السيرة الذاتية (PDF فقط - 5MB)</label>
+            <input type="file" class="form-control" id="cvUpload" accept=".pdf" required>
+          </div>
+          <div class="d-grid">
+            <button type="submit" class="btn btn-primary" id="submitBtn">إرسال</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <script src="job.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace former form index with home page linking to contact and jobs
- Create job application page without user type/inquiry selections
- Redirect inbox view to hide empty fields when not provided

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d34cc7bc832eaff62901f216c466