### PR TITLE
Add home navigation and update inquiry form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -12,6 +12,7 @@
   <div class="container py-5">
     <div class="card contact-card">
       <div class="card-header contact-header text-center position-relative">
+        <a href="index.html" class="btn btn-secondary btn-sm position-absolute top-0 start-0 m-2">الرئيسية</a>
         <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
         <h3 id="formTitle">نموذج الاتصال</h3>
       </div>
@@ -31,15 +32,17 @@
             <label class="form-label" id="inquiryTypeLabel">نوع الاستفسار</label>
             <select class="form-select" id="inquiryType" required>
               <option value="">اختر</option>
-              <option value="job">وظيفة</option>
-              <option value="question">استفسار</option>
-              <option value="complaint">شكوى</option>
+              <option value="inquiry">استفسار</option>
+              <option value="investment">استثمار</option>
+              <option value="development">تطوير عقاري</option>
+              <option value="opportunity">فرصة عقارية</option>
+              <option value="other">اخرى</option>
             </select>
           </div>
 
           <div class="mb-3">
             <label class="form-label" id="subjectLabel">عنوان الرسالة</label>
-            <input type="text" class="form-control" id="subject" maxlength="50" required>
+            <input type="text" class="form-control" id="subject" maxlength="35" required>
           </div>
 
           <div class="mb-3">
@@ -57,12 +60,7 @@
             <input type="tel" class="form-control" id="phone" required>
           </div>
 
-          <div class="mb-3" id="cvField" style="display: none;">
-            <label class="form-label" id="cvLabel">تحميل السيرة الذاتية (PDF فقط - 5MB)</label>
-            <input type="file" class="form-control" id="cvUpload" accept=".pdf" required>
-          </div>
-
-          <div class="mb-3" id="messageField">
+          <div class="mb-3">
             <label class="form-label" id="messageLabel">نص الرسالة</label>
             <textarea class="form-control" id="message" rows="4" required></textarea>
           </div>

--- a/jobs.html
+++ b/jobs.html
@@ -11,6 +11,7 @@
   <div class="container py-5">
     <div class="card contact-card">
       <div class="card-header contact-header text-center position-relative">
+        <a href="index.html" class="btn btn-secondary btn-sm position-absolute top-0 start-0 m-2">الرئيسية</a>
         <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
         <h3 id="formTitle">نموذج التوظيف</h3>
       </div>
@@ -18,7 +19,7 @@
         <form id="jobForm" enctype="multipart/form-data" novalidate>
           <div class="mb-3">
             <label class="form-label" id="subjectLabel">عنوان الرسالة</label>
-            <input type="text" class="form-control" id="subject" maxlength="50" required>
+            <input type="text" class="form-control" id="subject" maxlength="35" required>
           </div>
           <div class="mb-3">
             <label class="form-label" id="fullNameLabel">الاسم الكامل</label>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,5 @@
 const userTypeSelect = document.getElementById("userType");
 const inquiryTypeSelect = document.getElementById("inquiryType");
-const jobOption = inquiryTypeSelect.querySelector("option[value='job']");
 
 const translations = {
   ar: {
@@ -12,7 +11,6 @@ const translations = {
     fullNameLabel: "الاسم الكامل",
     emailLabel: "البريد الإلكتروني",
     phoneLabel: "رقم التواصل",
-    cvLabel: "تحميل السيرة الذاتية (PDF فقط - 5MB)",
     messageLabel: "نص الرسالة",
     submitBtn: "إرسال",
     userTypeOptions: {
@@ -23,13 +21,11 @@ const translations = {
     },
     inquiryTypeOptions: {
       placeholder: "اختر",
-      job: "وظيفة",
-      question: "استفسار",
-      complaint: "شكوى"
-    },
-    alerts: {
-      pdf: "⚠️ يجب أن يكون الملف بصيغة PDF",
-      size: "⚠️ الحد الأقصى لحجم السيرة الذاتية هو 5 ميجابايت"
+      inquiry: "استفسار",
+      investment: "استثمار",
+      development: "تطوير عقاري",
+      opportunity: "فرصة عقارية",
+      other: "اخرى"
     }
   },
   en: {
@@ -41,7 +37,6 @@ const translations = {
     fullNameLabel: "Full Name",
     emailLabel: "Email",
     phoneLabel: "Phone Number",
-    cvLabel: "Upload CV (PDF only - 5MB)",
     messageLabel: "Message",
     submitBtn: "Send",
     userTypeOptions: {
@@ -52,13 +47,11 @@ const translations = {
     },
     inquiryTypeOptions: {
       placeholder: "Select",
-      job: "Job",
-      question: "Inquiry",
-      complaint: "Complaint"
-    },
-    alerts: {
-      pdf: "⚠️ File must be PDF",
-      size: "⚠️ CV size limit is 5MB"
+      inquiry: "Inquiry",
+      investment: "Investment",
+      development: "Real Estate Development",
+      opportunity: "Real Estate Opportunity",
+      other: "Other"
     }
   }
 };
@@ -78,7 +71,6 @@ function setLanguage(lang) {
   document.getElementById("fullNameLabel").textContent = t.fullNameLabel;
   document.getElementById("emailLabel").textContent = t.emailLabel;
   document.getElementById("phoneLabel").textContent = t.phoneLabel;
-  document.getElementById("cvLabel").textContent = t.cvLabel;
   document.getElementById("messageLabel").textContent = t.messageLabel;
   document.getElementById("submitBtn").textContent = t.submitBtn;
 
@@ -88,9 +80,11 @@ function setLanguage(lang) {
   userTypeSelect.querySelector("option[value='government']").textContent = t.userTypeOptions.government;
 
   inquiryTypeSelect.querySelector("option[value='']").textContent = t.inquiryTypeOptions.placeholder;
-  inquiryTypeSelect.querySelector("option[value='job']").textContent = t.inquiryTypeOptions.job;
-  inquiryTypeSelect.querySelector("option[value='question']").textContent = t.inquiryTypeOptions.question;
-  inquiryTypeSelect.querySelector("option[value='complaint']").textContent = t.inquiryTypeOptions.complaint;
+  inquiryTypeSelect.querySelector("option[value='inquiry']").textContent = t.inquiryTypeOptions.inquiry;
+  inquiryTypeSelect.querySelector("option[value='investment']").textContent = t.inquiryTypeOptions.investment;
+  inquiryTypeSelect.querySelector("option[value='development']").textContent = t.inquiryTypeOptions.development;
+  inquiryTypeSelect.querySelector("option[value='opportunity']").textContent = t.inquiryTypeOptions.opportunity;
+  inquiryTypeSelect.querySelector("option[value='other']").textContent = t.inquiryTypeOptions.other;
 }
 
 document.getElementById("langToggle").addEventListener("click", () => {
@@ -98,53 +92,13 @@ document.getElementById("langToggle").addEventListener("click", () => {
   setLanguage(currentLang);
 });
 
-userTypeSelect.addEventListener("change", function () {
-  const hideJob = this.value === "company" || this.value === "government";
-  jobOption.hidden = hideJob;
-  if (hideJob && inquiryTypeSelect.value === "job") {
-    inquiryTypeSelect.value = "";
-    inquiryTypeSelect.dispatchEvent(new Event("change"));
-  }
-});
-
-inquiryTypeSelect.addEventListener("change", function () {
-  const isJob = this.value === "job";
-  const cvField = document.getElementById("cvField");
-  const cvInput = document.getElementById("cvUpload");
-  const messageField = document.getElementById("messageField");
-  const messageInput = document.getElementById("message");
-
-  cvField.style.display = isJob ? "block" : "none";
-  cvInput.required = isJob;
-
-  messageField.style.display = isJob ? "none" : "block";
-  messageInput.required = !isJob;
-});
-
 document.getElementById("contactForm").addEventListener("submit", function (e) {
   e.preventDefault();
 
-  const cvInput = document.getElementById("cvUpload");
-  const isJob = inquiryTypeSelect.value === "job";
-
-  if (isJob && cvInput.files.length > 0) {
-    const file = cvInput.files[0];
-    const ext = file.name.split(".").pop().toLowerCase();
-    if (ext !== "pdf") {
-      alert(translations[currentLang].alerts.pdf);
-      return;
-    }
-    if (file.size > 5 * 1024 * 1024) {
-      alert(translations[currentLang].alerts.size);
-      return;
-    }
-  }
-
-  const to = isJob ? "career@example.com" : "info@example.com";
   const inquiryText = inquiryTypeSelect.options[inquiryTypeSelect.selectedIndex].textContent;
 
   const params = new URLSearchParams({
-    to,
+    to: "info@example.com",
     subject: `${inquiryText} - ${document.getElementById("subject").value}`,
     name: document.getElementById("fullName").value,
     email: document.getElementById("email").value,
@@ -152,7 +106,7 @@ document.getElementById("contactForm").addEventListener("submit", function (e) {
     userType: userTypeSelect.value,
     inquiryType: inquiryTypeSelect.value,
     message: document.getElementById("message").value || "",
-    filename: isJob && cvInput.files.length > 0 ? cvInput.files[0].name : ""
+    filename: ""
   });
 
   window.location.href = `inbox.html?${params.toString()}`;
@@ -160,5 +114,4 @@ document.getElementById("contactForm").addEventListener("submit", function (e) {
 
 setLanguage("ar");
 
-inquiryTypeSelect.dispatchEvent(new Event("change"));
 


### PR DESCRIPTION
## Summary
- add links to return to the homepage on contact and job pages
- update inquiry types and enforce subject length
- simplify contact form logic without CV upload

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d650c574832e911d706b77857919