### PR TITLE
Standardize header language controls

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,7 @@
   <div class="container py-5">
     <div class="card jobs-card">
       <div class="card-header jobs-header text-center position-relative">
-        <a href="index.html" class="btn btn-secondary btn-sm position-absolute top-0 start-0 m-2">الرئيسية</a>
+        <a id="homeBtn" href="index.html" class="btn btn-secondary btn-sm position-absolute top-0 start-0 m-2">الرئيسية</a>
         <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
         <h3 id="formTitle">نموذج الاتصال</h3>
       </div>

--- a/inbox.html
+++ b/inbox.html
@@ -11,7 +11,7 @@
 
   <div class="container py-5">
     <div class="card shadow">
-      <div class="card-header bg-primary text-white position-relative">
+      <div class="card-header bg-primary text-white text-center position-relative">
         <a href="index.html" class="btn btn-secondary btn-sm position-absolute top-0 start-0 m-2" id="homeBtn">الرئيسية</a>
         <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
         <h4 class="mb-0" id="inboxTitle">📥 رسالة جديدة</h4>

--- a/index.html
+++ b/index.html
@@ -10,14 +10,51 @@
 <body>
   <div class="container py-5">
     <div class="card jobs-card text-center">
-      <div class="card-header jobs-header">
-        <h3>شركة العدوان</h3>
+      <div class="card-header jobs-header text-center position-relative">
+        <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
+        <h3 id="siteTitle">شركة العدوان</h3>
       </div>
       <div class="card-body d-grid gap-3">
-        <a href="contact.html" class="btn btn-primary btn-lg">اتصل بنا</a>
-        <a href="jobs.html" class="btn btn-secondary btn-lg">الوظائف</a>
+        <a id="contactBtn" href="contact.html" class="btn btn-primary btn-lg">اتصل بنا</a>
+        <a id="jobsBtn" href="jobs.html" class="btn btn-secondary btn-lg">الوظائف</a>
       </div>
     </div>
   </div>
+
+  <script>
+    const translations = {
+      ar: {
+        langToggle: 'English',
+        siteTitle: 'شركة العدوان',
+        contactBtn: 'اتصل بنا',
+        jobsBtn: 'الوظائف'
+      },
+      en: {
+        langToggle: 'العربية',
+        siteTitle: 'Aladwan Company',
+        contactBtn: 'Contact Us',
+        jobsBtn: 'Jobs'
+      }
+    };
+
+    let currentLang = 'ar';
+
+    function setLanguage(lang) {
+      const t = translations[lang];
+      document.documentElement.lang = lang;
+      document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+      document.getElementById('langToggle').textContent = t.langToggle;
+      document.getElementById('siteTitle').textContent = t.siteTitle;
+      document.getElementById('contactBtn').textContent = t.contactBtn;
+      document.getElementById('jobsBtn').textContent = t.jobsBtn;
+    }
+
+    document.getElementById('langToggle').addEventListener('click', () => {
+      currentLang = currentLang === 'ar' ? 'en' : 'ar';
+      setLanguage(currentLang);
+    });
+
+    setLanguage('ar');
+  </script>
 </body>
 </html>

--- a/jobs.html
+++ b/jobs.html
@@ -30,24 +30,16 @@
       display: none;
       margin-top: 10px;
     }
-    .lang-toggle {
-      position: absolute;
-      top: 20px;
-      left: 20px;
-      z-index: 10;
-    }
   </style>
 </head>
 <body>
-
-  <!-- زر تبديل اللغة -->
-  <button class="btn btn-outline-dark lang-toggle" id="langToggle">English</button>
-
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-md-9 col-lg-8">
         <div class="card jobs-card">
-          <div class="card-header jobs-header">
+          <div class="card-header jobs-header text-center position-relative">
+            <a id="homeBtn" href="index.html" class="btn btn-secondary btn-sm position-absolute top-0 start-0 m-2">الرئيسية</a>
+            <button id="langToggle" class="btn btn-secondary btn-sm position-absolute top-0 end-0 m-2">English</button>
             <h3 id="pageHeading">الوظائف المتاحة</h3>
             <p id="pageSubHeading">نرحب بالمواهب المؤهلة للانضمام إلى فريقنا</p>
           </div>
@@ -139,7 +131,7 @@
               <button class="btn btn-outline-secondary btn-sm" id="backBtn">
                 العودة إلى النموذج
               </button>
-              <a href="index.html" class="btn btn-primary btn-sm ms-2" id="homeBtn">الرئيسية</a>
+              <a href="index.html" class="btn btn-primary btn-sm ms-2" id="homeBtnBottom">الرئيسية</a>
             </div>
           </div>
         </div>
@@ -150,6 +142,7 @@
   <script>
     const translations = {
       ar: {
+        langToggle: "English",
         pageHeading: "الوظائف المتاحة",
         pageSubHeading: "نرحب بالمواهب المؤهلة للانضمام إلى فريقنا",
         subjectLabel: "عنوان الرسالة (35 حرفًا كحد أقصى)",
@@ -169,6 +162,7 @@
         bodyLabel: "تفاصيل الطلب:",
         backBtn: "العودة إلى النموذج",
         homeBtn: "الرئيسية",
+        homeBtnBottom: "الرئيسية",
         captchaLabel: "رمز التحقق",
         captchaError: "رمز التحقق غير صحيح",
         spamMessage: "يحتوي النموذج على محتوى غير مسموح به. يُرجى التحقق من المدخلات.",
@@ -177,6 +171,7 @@
         suspiciousContent: "تم اكتشاف محتوى مشبوه (روابط، تعليمات برمجية)."
       },
       en: {
+        langToggle: "العربية",
         pageHeading: "Available Jobs",
         pageSubHeading: "We welcome qualified talents to join our team",
         subjectLabel: "Subject (max 35 characters)",
@@ -196,6 +191,7 @@
         bodyLabel: "Application Details:",
         backBtn: "Back to Form",
         homeBtn: "Home",
+        homeBtnBottom: "Home",
         captchaLabel: "Captcha",
         captchaError: "Incorrect captcha",
         spamMessage: "The form contains prohibited content. Please review your inputs.",
@@ -207,6 +203,16 @@
 
     let currentLang = 'ar';
 
+    function setLanguage(lang) {
+      document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+      document.documentElement.lang = lang;
+      Object.keys(translations.ar).forEach(key => {
+        const element = document.getElementById(key);
+        if (element) element.textContent = translations[lang][key];
+      });
+      document.getElementById('phone').placeholder = '+966 XXX XXX XXXX';
+    }
+
     let captchaValue;
     const generateCaptcha = () => Math.floor(1000 + Math.random() * 9000).toString();
     const refreshCaptcha = () => {
@@ -215,20 +221,11 @@
     };
     refreshCaptcha();
 
-    // تبديل اللغة
     document.getElementById('langToggle').addEventListener('click', function () {
       currentLang = currentLang === 'ar' ? 'en' : 'ar';
-      this.textContent = currentLang === 'ar' ? 'English' : 'العربية';
-      document.documentElement.dir = currentLang === 'ar' ? 'rtl' : 'ltr';
-      document.documentElement.lang = currentLang;
-
-      Object.keys(translations.ar).forEach(key => {
-        const element = document.getElementById(key);
-        if (element) element.textContent = translations[currentLang][key];
-      });
-
-      document.getElementById('phone').placeholder = currentLang === 'ar' ? '+966 XXX XXX XXXX' : '+966 XXX XXX XXXX';
+      setLanguage(currentLang);
     });
+    setLanguage('ar');
 
     // عداد الأحرف
     document.getElementById("subject").addEventListener("input", function () {

--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ const translations = {
     captchaLabel: "رمز التحقق",
     captchaError: "رمز التحقق غير صحيح",
     submitBtn: "إرسال",
+    homeBtn: "الرئيسية",
     userTypeOptions: {
       placeholder: "اختر",
       individual: "فرد",
@@ -45,6 +46,7 @@ const translations = {
     captchaLabel: "Captcha",
     captchaError: "Incorrect captcha",
     submitBtn: "Send",
+    homeBtn: "Home",
     userTypeOptions: {
       placeholder: "Select",
       individual: "Individual",
@@ -80,6 +82,7 @@ function setLanguage(lang) {
   document.getElementById("messageLabel").textContent = t.messageLabel;
   document.getElementById("captchaLabel").textContent = t.captchaLabel;
   document.getElementById("submitBtn").textContent = t.submitBtn;
+  document.getElementById("homeBtn").textContent = t.homeBtn;
 
   userTypeSelect.querySelector("option[value='']").textContent = t.userTypeOptions.placeholder;
   userTypeSelect.querySelector("option[value='individual']").textContent = t.userTypeOptions.individual;


### PR DESCRIPTION
## Summary
- Harmonize header layout across forms with consistent home and language buttons
- Add language toggle on the home page and ensure translations cover home button
- Update job application page with unified header and translation handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e30bc214832eaded20deb5b6be7c